### PR TITLE
Add multi-architecture packaging and Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install build dependencies
         run: |
           brew update
-          brew install autoconf automake pkg-config protobuf boost openssl@3
+          brew install autoconf automake libtool pkg-config protobuf boost openssl@3
 
       - name: Build macOS ${{ matrix.arch }} artifacts
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,134 +1,113 @@
-name: Release
+name: build-and-release
 
 on:
-  push:
-    tags:
-      # This syntax is globs, not regex, so it's matching any tag that
-      # contains the prefix "mosh-" and the 3 version elements.
-      - "mosh-*.*.*"
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
-  macports-cache:
-    runs-on: macos-12
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: "Install gtar wrapper"
-      run: |
-        sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
-        sudo cp macosx/gtar /usr/local/bin/gtar
-        sudo chmod +x /usr/local/bin/gtar
-
-    - name: Cache macports
-      id: cache-macports
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-macports
-      with:
-        path: /opt/local
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('macosx/port-deps.sh') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    - name: "setup MacPorts environment"
-      run: |
-        curl -L "https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2-12-Monterey.pkg" --output macports.pkg
-        sudo installer -pkg macports.pkg -target /
-        ./macosx/port-deps.sh deps
-
-  release:
-    needs: macports-cache
-    runs-on: ${{ matrix.os }}
-
+  build-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
-
+        include:
+          - arch: amd64
+            run_arch: x86_64
+          - arch: arm64
+            run_arch: aarch64
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
 
-    - name: "ensure version bumped"
-      run: |
-        expected_tag=$(echo ${{ github.ref }} | cut -d'/' -f3)
-        have_tag="mosh-$(sed -n 's/AC_INIT(\[[^]]*\], \[\([^]]*\)\].*/\1/p' <configure.ac)"
-        echo "Expected tag <$expected_tag>, got <$have_tag>"
-        if [[ "$expected_tag" != "$have_tag" ]]; then exit 1; fi
+      - name: Build Linux ${{ matrix.arch }} artifacts
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: ${{ matrix.run_arch }}
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          env: |
+            TARGET_OS=linux
+            TARGET_ARCH=${{ matrix.arch }}
+            PACKAGE_FORMATS=deb,rpm
+          install: |
+            apt-get update
+            apt-get install -y \
+              autoconf automake libtool pkg-config \
+              protobuf-compiler libprotobuf-dev \
+              libncurses-dev libssl-dev zlib1g-dev libboost-all-dev \
+              ruby ruby-dev build-essential rpm
+            gem install --no-document fpm
+          run: |
+            scripts/package-release.sh
 
-    - name: "setup linux build environment"
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      run: sudo apt install -y protobuf-compiler libprotobuf-dev libutempter-dev autoconf automake nettle-dev
+      - name: Upload Linux ${{ matrix.arch }} artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mosh-plus-linux-${{ matrix.arch }}
+          path: |
+            build/release/artifacts/*.tar.gz
+            build/release/artifacts/*.sha256
+            build/release/artifacts/*.deb
+            build/release/artifacts/*.rpm
 
-    - name: "Install gtar wrapper"
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      run: |
-        sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
-        sudo cp macosx/gtar /usr/local/bin/gtar
-        sudo chmod +x /usr/local/bin/gtar
+      - name: Attach Linux ${{ matrix.arch }} artifacts to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/release/artifacts/*.tar.gz
+            build/release/artifacts/*.sha256
+            build/release/artifacts/*.deb
+            build/release/artifacts/*.rpm
 
-    - name: Restore macports cache
-      id: cache-macports
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-macports
-      with:
-        path: /opt/local
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('macosx/port-deps.sh') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+  build-macos:
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - runner: macos-13
+            arch: amd64
+          - runner: macos-14
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
 
-    - name: "describe macos build environment"
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      run: |
-        BUILD_TAG=$(echo ${{ github.ref }} | cut -d'/' -f3)
-        mkdir macosx/build-report &&
-        pushd macosx/build-report &&
-        ../port-deps.sh describe &&
-        ../osx-xcode.sh describe &&
-        tar -cjf "../${BUILD_TAG}-osx-build-report.tbz" . &&
-        popd
+      - name: Install build dependencies
+        run: |
+          brew update
+          brew install autoconf automake pkg-config protobuf boost openssl@3
 
-    - name: "generate build scripts"
-      run: PATH=/opt/local/bin:$PATH ./autogen.sh
+      - name: Build macOS ${{ matrix.arch }} artifacts
+        env:
+          TARGET_OS: darwin
+          TARGET_ARCH: ${{ matrix.arch }}
+        run: |
+          export OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+          export CPPFLAGS="-I${OPENSSL_PREFIX}/include ${CPPFLAGS}"
+          export LDFLAGS="-L${OPENSSL_PREFIX}/lib ${LDFLAGS}"
+          scripts/package-release.sh
 
-    - name: "configure"
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      run: ./configure --enable-compile-warnings=error --enable-examples
+      - name: Upload macOS ${{ matrix.arch }} artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mosh-plus-macos-${{ matrix.arch }}
+          path: |
+            build/release/artifacts/*.tar.gz
+            build/release/artifacts/*.sha256
 
-    - name: "build"
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      run: make V=1
-
-    - name: "test"
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      run: make V=1 distcheck -j
-
-    - name: "unshallow git repository for git describe"
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      run: git fetch --tags --unshallow -f
-
-    - name: "macOS package build"
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      run: |
-        pushd macosx &&
-        env ZERO_AR_DATE=1 MACOSX_DEPLOYMENT_TARGET=11.0 PATH=/opt/local/bin:$PATH ./build.sh &&
-        popd
-
-    - name: "Upload Release"
-      # v1 aka v0.1.14 as of 2022-07-05; pinned to avoid potential code injection
-      uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
-      with:
-        # Action always creates releases in "draft" mode, and requires
-        # a maintainer to publish them
-        draft: True
-        prerelease: ${{ contains(github.ref, 'rc') }}
-        generate_release_notes: True
-        files: |
-          mosh-*.tar.gz
-          macosx/*.pkg
-          macosx/*-osx-build-report.tbz
+      - name: Attach macOS ${{ matrix.arch }} artifacts to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/release/artifacts/*.tar.gz
+            build/release/artifacts/*.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ src/include/config.h.in~
 /install-sh
 /missing
 /mosh-*.tar.gz
+/build/
 src/include/stamp-h1
 /test-driver
 /VERSION

--- a/Formula/mosh-plus.rb
+++ b/Formula/mosh-plus.rb
@@ -1,0 +1,26 @@
+class MoshPlus < Formula
+  desc "Mobile shell with experimental mouse forwarding"
+  homepage "https://github.com/mosh-plus/mosh-plus"
+  head "https://github.com/mosh-plus/mosh-plus.git", branch: "main"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "protobuf"
+  depends_on "openssl@3"
+  depends_on "readline"
+
+  def install
+    ENV.append "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib}"
+    ENV.append "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include}"
+
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_match "mosh", shell_output("#{bin}/mosh --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -63,6 +63,105 @@ Getting Mosh
   packages for many operating systems, as well as instructions for building
   from source.
 
+Installing the mouse-enabled build from source
+----------------------------------------------
+
+  The mouse-forwarding functionality lives behind the normal Mosh build system
+  and does not require any special configuration flags. To build from a fresh
+  clone, install the standard build dependencies (see "Notes for developers"
+  below) and then run:
+
+  ```
+  $ ./autogen.sh
+  $ ./configure
+  $ make
+  $ sudo make install    # optional, installs into /usr/local by default
+  ```
+
+  These steps produce `mosh-client`, `mosh-server`, and the wrapper script with
+  mouse support. You can also copy the `src/frontend/mosh-{client,server}`
+  binaries out of the build tree if you prefer not to install system-wide.
+
+Creating binary release artifacts
+---------------------------------
+
+  The repository now ships with an enhanced `scripts/package-release.sh`, which
+  automates a reproducible out-of-tree install and collects the resulting
+  binaries into a compressed tarball alongside a SHA-256 checksum. The script
+  accepts optional `TARGET_OS`, `TARGET_ARCH`, and `PACKAGE_FORMATS`
+  environment variables so you can create native bundles for Linux, macOS on
+  Intel or Apple Silicon, or other supported hosts:
+
+  ```
+  $ TARGET_OS=linux TARGET_ARCH=arm64 PACKAGE_FORMATS=deb,rpm \
+      scripts/package-release.sh
+  $ ls build/release/artifacts
+  mosh-plus-1.4.0-abcd123-linux-arm64.tar.gz
+  mosh-plus-1.4.0-abcd123-linux-arm64.tar.gz.sha256
+  mosh-plus_1.4.0-abcd123_arm64.deb
+  mosh-plus-1.4.0-abcd123.aarch64.rpm
+  ```
+
+  The tarballs contain the `/usr/local` tree created by `make install`, so you
+  can unpack them on a target system with root privileges to deploy the
+  binaries:
+
+  ```
+  # tar -C /usr/local -xzf mosh-plus-1.4.0-abcd123-linux-arm64.tar.gz
+  ```
+
+  When `PACKAGE_FORMATS` includes `deb` or `rpm` the script uses
+  [`fpm`](https://fpm.readthedocs.io/) to turn the staged install tree into
+  packages consumable by `apt`/`dpkg` and `yum`/`dnf`. This makes it possible to
+  ship native Linux packages alongside the compressed archives without
+  maintaining separate packaging specs.
+
+  For GitHub-hosted projects, publishing a release automatically triggers the
+  `build-and-release` workflow under `.github/workflows/release.yml`. The job
+  now builds on Ubuntu (amd64 and arm64) and macOS (Intel and Apple Silicon),
+  installs the necessary build dependencies, invokes the packaging script with
+  the appropriate environment, and uploads the tarballs, checksums, and native
+  packages as release assets. You can also launch the workflow manually via the
+  “Run workflow” button if you want fresh artifacts without cutting a tag.
+
+Installing prebuilt packages
+----------------------------
+
+  Every release publishes ready-to-install bundles for the most common package
+  managers. After downloading the asset that matches your platform, install it
+  with the native tooling:
+
+  * **Debian/Ubuntu (amd64 or arm64)**
+
+    ```
+    $ sudo apt install ./mosh-plus_1.4.0-abcd123_amd64.deb
+    ```
+
+  * **Fedora/RHEL/CentOS (x86_64 or aarch64)**
+
+    ```
+    $ sudo dnf install mosh-plus-1.4.0-abcd123.x86_64.rpm
+    ```
+
+    Replace `dnf` with `yum` on older distributions.
+
+  * **macOS (Intel or Apple Silicon)**
+
+    ```
+    $ sudo tar -C /usr/local -xzf mosh-plus-1.4.0-abcd123-darwin-arm64.tar.gz
+    ```
+
+  Users who prefer to let Homebrew track the installation can tap the formula
+  shipped with the repository:
+
+  ```
+  $ brew tap mosh-plus/tap https://github.com/mosh-plus/mosh-plus.git
+  $ brew install mosh-plus
+  ```
+
+  The tap exposes the HEAD build by default so you can stay current between
+  tagged releases. See `Formula/mosh-plus.rb` for the full formula definition.
+
   Note that `mosh-client` receives an AES session key as an environment
   variable.  If you are porting Mosh to a new operating system, please make
   sure that a running process's environment variables are not readable by other
@@ -83,6 +182,19 @@ Usage
   `$PATH`, `mosh` accepts the arguments `--client=PATH` and `--server=PATH` to
   select alternate locations. More options are documented in the mosh(1) manual
   page.
+
+  Mouse input forwarding is disabled by default to preserve compatibility.
+  When both the local client and remote server are running this fork, pass the
+  `--enable-mouse` option to `mosh` to activate experimental forwarding of
+  scroll, click, and movement events:
+
+  ```
+  $ mosh --enable-mouse [user@]host
+  ```
+
+  The wrapper will ensure that the flag propagates to both the client and
+  server binaries. Applications such as `vim`, `htop`, and `less` can then
+  receive translated xterm mouse sequences over the PTY.
 
   There are [more examples](https://mosh.org/#usage) and a
   [FAQ](https://mosh.org/#faq) on the Mosh web site.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ $ sudo apt install -y build-essential protobuf-compiler \
 MacOS:
 
 ```
-$ brew install protobuf automake
+$ brew install autoconf automake libtool pkg-config protobuf
 ```
 
 Once you have forked the repository, run the following to build and test Mosh:

--- a/man/mosh.1
+++ b/man/mosh.1
@@ -155,6 +155,14 @@ if its value is 'yes'.
 Synonym for \-\-predict\-overwrite
 
 .TP
+.B \-\-enable-mouse
+Enable experimental forwarding of mouse scroll, click, and movement
+events when supported by both client and server. This option is
+disabled by default for compatibility with older releases. It is safe
+to pass even if the remote side lacks support; the connection will
+automatically fall back to standard keyboard-only input.
+
+.TP
 .B \-\-family=inet
 Only use IPv4 for the SSH connection and Mosh session.
 
@@ -222,6 +230,14 @@ the SSH connection appear to come from localhost.
 
 With \-\-bind\-server=\fIIP\fP, the server will attempt to bind to the
 specified IP address.
+
+.TP
+.B \-\-enable\-mouse
+Enable experimental forwarding of mouse input. When set, \fBmosh\fP captures
+scroll, button, and motion events from the local terminal and sends them to the
+server using Xterm-compatible escape sequences. This option must be supported
+by both the client and server and is disabled by default to preserve
+compatibility.
 
 .TP
 .B \-\-no\-init

--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -86,6 +86,8 @@ my $ssh_pty = 1;
 my $help = undef;
 my $version = undef;
 
+my $enable_mouse = 0;
+
 my @cmdline = @ARGV;
 
 my $usage =
@@ -113,6 +115,7 @@ qq{Usage: $0 [options] [--] [user@]host [command...]
                                 (No effect on server-side SSH port)
         --bind-server={ssh|any|IP}  ask the server to reply from an IP address
                                        (default: "ssh")
+        --enable-mouse         enable mouse event forwarding (experimental)
 
         --ssh=COMMAND        ssh command to run when setting up session
                                 (example: "ssh -p 2222")
@@ -166,12 +169,13 @@ GetOptions( 'client=s' => \$client,
 	    'ssh=s' => sub { @ssh = shellwords($_[1]); },
 	    'ssh-pty!' => \$ssh_pty,
 	    'init!' => \$term_init,
-	    'local' => \$localhost,
-	    'help' => \$help,
-	    'version' => \$version,
-	    'fake-proxy!' => \my $fake_proxy,
-	    'bind-server=s' => \$bind_ip,
-	    'experimental-remote-ip=s' => \$use_remote_ip) or die $usage;
+            'local' => \$localhost,
+            'help' => \$help,
+            'version' => \$version,
+            'fake-proxy!' => \my $fake_proxy,
+            'bind-server=s' => \$bind_ip,
+            'enable-mouse!' => \$enable_mouse,
+            'experimental-remote-ip=s' => \$use_remote_ip) or die $usage;
 
 if ( defined $help ) {
     print $usage;
@@ -384,6 +388,8 @@ if ( $pid == 0 ) { # child
     push @server, ( '-p', $port_request );
   }
 
+  push @server, '--enable-mouse' if $enable_mouse;
+
   for ( &locale_vars ) {
     push @server, ( '-l', $_ );
   }
@@ -462,7 +468,10 @@ if ( $pid == 0 ) { # child
   $ENV{ 'MOSH_KEY' } = $key;
   $ENV{ 'MOSH_PREDICTION_DISPLAY' } = $predict;
   $ENV{ 'MOSH_NO_TERM_INIT' } = '1' if !$term_init;
-  exec {$client} ("$client", "-# @cmdline |", $ip, $port);
+  my @client_args = ("$client");
+  push @client_args, '--enable-mouse' if $enable_mouse;
+  push @client_args, "-# @cmdline |", $ip, $port;
+  exec {$client} @client_args;
 }
 
 sub shell_quote { join ' ', map {(my $a = $_) =~ s/'/'\\''/g; "'$a'"} @_ }

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BUILD_DIR="${ROOT_DIR}/build/release"
+STAGE_DIR="${BUILD_DIR}/stage"
+ARTIFACT_DIR="${BUILD_DIR}/artifacts"
+
+mkdir -p "${STAGE_DIR}" "${ARTIFACT_DIR}"
+
+# Derive the project version from configure.ac and include the short git SHA so
+# users can quickly map artifacts back to a commit.
+PROJECT_VERSION=${PROJECT_VERSION:-$(sed -n 's/AC_INIT([^,]*, *\[\([^]]*\)\],.*/\1/p' "${ROOT_DIR}/configure.ac")}
+GIT_REVISION=$(git -C "${ROOT_DIR}" rev-parse --short HEAD)
+
+TARGET_OS=${TARGET_OS:-$(uname -s | tr '[:upper:]' '[:lower:]')}
+TARGET_ARCH_RAW=${TARGET_ARCH:-$(uname -m)}
+
+case "${TARGET_ARCH_RAW}" in
+  x86_64|amd64)
+    TARGET_ARCH_CANON="amd64"
+    FPM_ARCH_DEB="amd64"
+    FPM_ARCH_RPM="x86_64"
+    ;;
+  arm64|aarch64)
+    TARGET_ARCH_CANON="arm64"
+    FPM_ARCH_DEB="arm64"
+    FPM_ARCH_RPM="aarch64"
+    ;;
+  *)
+    TARGET_ARCH_CANON="${TARGET_ARCH_RAW}"
+    FPM_ARCH_DEB="${TARGET_ARCH_RAW}"
+    FPM_ARCH_RPM="${TARGET_ARCH_RAW}"
+    ;;
+esac
+
+ARTIFACT_NAME=${ARTIFACT_NAME:-"mosh-plus-${PROJECT_VERSION}-${GIT_REVISION}-${TARGET_OS}-${TARGET_ARCH_CANON}"}
+
+# Allow callers to pass additional configure flags through the CONFIGURE_FLAGS
+# environment variable without editing the script.
+CONFIGURE_FLAGS=${CONFIGURE_FLAGS:-""}
+
+if command -v nproc >/dev/null 2>&1; then
+  DEFAULT_JOBS="-j$(nproc)"
+elif command -v getconf >/dev/null 2>&1; then
+  DEFAULT_JOBS="-j$(getconf _NPROCESSORS_ONLN)"
+else
+  DEFAULT_JOBS=""
+fi
+
+MAKEFLAGS=${MAKEFLAGS:-"${DEFAULT_JOBS}"}
+
+pushd "${ROOT_DIR}" >/dev/null
+
+./autogen.sh
+CONFIGURE_ARGS=("--prefix=/usr/local")
+if [[ -n "${CONFIGURE_FLAGS}" ]]; then
+  # shellcheck disable=SC2206 # Intentional word splitting to support multiple flags.
+  EXTRA_ARGS=(${CONFIGURE_FLAGS})
+  CONFIGURE_ARGS+=("${EXTRA_ARGS[@]}")
+fi
+./configure "${CONFIGURE_ARGS[@]}"
+make ${MAKEFLAGS}
+rm -rf "${STAGE_DIR}"
+make install DESTDIR="${STAGE_DIR}"
+
+popd >/dev/null
+
+TARBALL_PATH="${ARTIFACT_DIR}/${ARTIFACT_NAME}.tar.gz"
+INSTALL_ROOT="${STAGE_DIR}/usr/local"
+
+if [[ ! -d "${INSTALL_ROOT}" ]]; then
+  echo "Expected install root ${INSTALL_ROOT} to exist" >&2
+  exit 1
+fi
+
+tar -C "${INSTALL_ROOT}" -czf "${TARBALL_PATH}" .
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "${TARBALL_PATH}" > "${TARBALL_PATH}.sha256"
+else
+  shasum -a 256 "${TARBALL_PATH}" > "${TARBALL_PATH}.sha256"
+fi
+
+PACKAGE_FORMATS=${PACKAGE_FORMATS:-""}
+if [[ -n "${PACKAGE_FORMATS}" ]]; then
+  IFS=',' read -r -a FORMATS <<< "${PACKAGE_FORMATS}"
+  for format in "${FORMATS[@]}"; do
+    case "${format}" in
+      deb|rpm)
+        if ! command -v fpm >/dev/null 2>&1; then
+          echo "Skipping ${format} package: fpm is not installed" >&2
+          continue
+        fi
+        PACKAGE_ITERATION=${PACKAGE_ITERATION:-${GIT_REVISION}}
+        PACKAGE_NAME=${PACKAGE_NAME:-mosh-plus}
+        PACKAGE_DESCRIPTION=${PACKAGE_DESCRIPTION:-"Enhanced Mosh build with mouse support"}
+        PACKAGE_URL=${PACKAGE_URL:-"https://github.com/mosh-plus/mosh-plus"}
+        PACKAGE_LICENSE=${PACKAGE_LICENSE:-"GPL-3.0-or-later"}
+        PACKAGE_MAINTAINER=${PACKAGE_MAINTAINER:-"Mosh Plus Team <support@mosh-plus.invalid>"}
+        case "${format}" in
+          deb)
+            OUTPUT_PATH="${ARTIFACT_DIR}/${PACKAGE_NAME}_${PROJECT_VERSION}-${PACKAGE_ITERATION}_${FPM_ARCH_DEB}.deb"
+            fpm -s dir -t deb \
+              -n "${PACKAGE_NAME}" \
+              -v "${PROJECT_VERSION}" \
+              --iteration "${PACKAGE_ITERATION}" \
+              --architecture "${FPM_ARCH_DEB}" \
+              --description "${PACKAGE_DESCRIPTION}" \
+              --url "${PACKAGE_URL}" \
+              --license "${PACKAGE_LICENSE}" \
+              --maintainer "${PACKAGE_MAINTAINER}" \
+              --prefix /usr/local \
+              --package "${OUTPUT_PATH}" \
+              -C "${STAGE_DIR}" usr/local || {
+                echo "Failed to build deb package" >&2
+                continue
+              }
+            ;;
+          rpm)
+            OUTPUT_PATH="${ARTIFACT_DIR}/${PACKAGE_NAME}-${PROJECT_VERSION}-${PACKAGE_ITERATION}.${FPM_ARCH_RPM}.rpm"
+            fpm -s dir -t rpm \
+              -n "${PACKAGE_NAME}" \
+              -v "${PROJECT_VERSION}" \
+              --iteration "${PACKAGE_ITERATION}" \
+              --architecture "${FPM_ARCH_RPM}" \
+              --description "${PACKAGE_DESCRIPTION}" \
+              --url "${PACKAGE_URL}" \
+              --license "${PACKAGE_LICENSE}" \
+              --maintainer "${PACKAGE_MAINTAINER}" \
+              --prefix /usr/local \
+              --package "${OUTPUT_PATH}" \
+              -C "${STAGE_DIR}" usr/local || {
+                echo "Failed to build rpm package" >&2
+                continue
+              }
+            ;;
+        esac
+        ;;
+      *)
+        echo "Unsupported package format: ${format}" >&2
+        ;;
+    esac
+  done
+fi
+
+echo "Release artifacts written to:"
+echo "  ${TARBALL_PATH}"
+echo "  ${TARBALL_PATH}.sha256"
+if [[ -n "${PACKAGE_FORMATS}" ]]; then
+  for format in "${FORMATS[@]}"; do
+    case "${format}" in
+      deb)
+        echo "  ${ARTIFACT_DIR}/${PACKAGE_NAME}_${PROJECT_VERSION}-${PACKAGE_ITERATION}_${FPM_ARCH_DEB}.deb"
+        ;;
+      rpm)
+        echo "  ${ARTIFACT_DIR}/${PACKAGE_NAME}-${PROJECT_VERSION}-${PACKAGE_ITERATION}.${FPM_ARCH_RPM}.rpm"
+        ;;
+    esac
+  done
+fi

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -34,6 +34,7 @@
 #include "src/include/version.h"
 
 #include <cstdlib>
+#include <vector>
 
 #include <unistd.h>
 
@@ -85,7 +86,7 @@ static void print_usage( FILE* file, const char* argv0 )
 {
   print_version( file );
   fprintf( file,
-           "\nUsage: %s [-# 'ARGS'] IP PORT\n"
+           "\nUsage: %s [--enable-mouse] [-# 'ARGS'] IP PORT\n"
            "       %s -c\n",
            argv0,
            argv0 );
@@ -117,6 +118,23 @@ int main( int argc, char* argv[] )
 
   /* Detect edge case */
   fatal_assert( argc > 0 );
+
+  bool enable_mouse = false;
+  std::vector<char*> argv_storage;
+  argv_storage.reserve( argc + 1 );
+  argv_storage.push_back( argv[0] );
+
+  for ( int i = 1; i < argc; i++ ) {
+    if ( 0 == strcmp( argv[i], "--enable-mouse" ) ) {
+      enable_mouse = true;
+      continue;
+    }
+    argv_storage.push_back( argv[i] );
+  }
+
+  argv_storage.push_back( nullptr );
+  argv = argv_storage.data();
+  argc = static_cast<int>( argv_storage.size() - 1 );
 
   /* Get arguments */
   for ( int i = 1; i < argc; i++ ) {
@@ -194,7 +212,7 @@ int main( int argc, char* argv[] )
 
   bool success = false;
   try {
-    STMClient client( ip, desired_port, key.c_str(), predict_mode, verbose, predict_overwrite );
+    STMClient client( ip, desired_port, key.c_str(), predict_mode, verbose, predict_overwrite, enable_mouse );
     client.init();
 
     try {

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -34,6 +34,7 @@
 #include "src/include/version.h"
 
 #include <cerrno>
+#include <cstdint>
 #include <clocale>
 #include <csignal>
 #include <cstdio>
@@ -42,6 +43,7 @@
 #include <ctime>
 #include <sstream>
 #include <typeinfo>
+#include <vector>
 
 #include <err.h>
 #include <fcntl.h>
@@ -104,13 +106,42 @@ static void serve( int host_fd,
                    long network_timeout,
                    long network_signaled_timeout );
 
+static std::string encode_mouse_event( const Network::MouseEvent& event )
+{
+  uint32_t cb = event.encoded;
+
+  if ( cb == 0 ) {
+    switch ( event.type ) {
+      case Network::MouseEvent::SCROLL_UP:
+        cb = 64;
+        break;
+      case Network::MouseEvent::SCROLL_DOWN:
+        cb = 65;
+        break;
+      case Network::MouseEvent::MOVE:
+        cb = ( event.button & 0x3 ) | 0x20;
+        break;
+      case Network::MouseEvent::CLICK:
+      default:
+        cb = event.button & 0x3;
+        break;
+    }
+  }
+
+  char final_char = event.release ? 'm' : 'M';
+  char buf[64];
+  snprintf( buf, sizeof( buf ), "\033[<%u;%u;%u%c", cb, event.x, event.y, final_char );
+  return std::string( buf );
+}
+
 static int run_server( const char* desired_ip,
                        const char* desired_port,
                        const std::string& command_path,
                        char* command_argv[],
                        const int colors,
                        unsigned int verbose,
-                       bool with_motd );
+                       bool with_motd,
+                       bool enable_mouse );
 
 static void print_version( FILE* file )
 {
@@ -192,6 +223,23 @@ int main( int argc, char* argv[] )
   unsigned int verbose = 0; /* don't close stdin/stdout/stderr */
   /* Will cause mosh-server not to correctly detach on old versions of sshd. */
   std::list<std::string> locale_vars;
+  bool enable_mouse = false;
+
+  std::vector<char*> argv_storage;
+  argv_storage.reserve( argc + 1 );
+  argv_storage.push_back( argv[0] );
+
+  for ( int i = 1; i < argc; i++ ) {
+    if ( 0 == strcmp( argv[i], "--enable-mouse" ) ) {
+      enable_mouse = true;
+      continue;
+    }
+    argv_storage.push_back( argv[i] );
+  }
+
+  argv_storage.push_back( nullptr );
+  argv = argv_storage.data();
+  argc = static_cast<int>( argv_storage.size() - 1 );
 
   /* strip off command */
   for ( int i = 1; i < argc; i++ ) {
@@ -372,7 +420,7 @@ int main( int argc, char* argv[] )
   }
 
   try {
-    return run_server( desired_ip, desired_port, command_path, command_argv, colors, verbose, with_motd );
+    return run_server( desired_ip, desired_port, command_path, command_argv, colors, verbose, with_motd, enable_mouse );
   } catch ( const Network::NetworkException& e ) {
     fprintf( stderr, "Network exception: %s\n", e.what() );
     return 1;
@@ -388,7 +436,8 @@ static int run_server( const char* desired_ip,
                        char* command_argv[],
                        const int colors,
                        unsigned int verbose,
-                       bool with_motd )
+                       bool with_motd,
+                       bool enable_mouse )
 {
   /* get network idle timeout */
   long network_timeout = 0;
@@ -435,6 +484,9 @@ static int run_server( const char* desired_ip,
   Network::UserStream blank;
   using NetworkPointer = std::shared_ptr<ServerConnection>;
   NetworkPointer network( new ServerConnection( terminal, blank, desired_ip, desired_port ) );
+
+  uint32_t capabilities = enable_mouse ? Network::MOSH_CAP_MOUSE : 0;
+  network->set_capabilities( capabilities );
 
   network->set_verbose( verbose );
   Select::set_verbose( verbose );
@@ -770,17 +822,24 @@ static void serve( int host_fd,
           us.apply_string( network.get_remote_diff() );
           /* apply userstream to terminal */
           for ( size_t i = 0; i < us.size(); i++ ) {
+            const Network::UserEvent& event = us.get_event( i );
+
+            if ( event.type == Network::MouseType ) {
+              terminal_to_host += encode_mouse_event( event.mouse );
+              continue;
+            }
+
             const Parser::Action& action = us.get_action( i );
-            if ( typeid( action ) == typeid( Parser::Resize ) ) {
+            if ( event.type == Network::ResizeType ) {
               /* apply only the last consecutive Resize action */
               if ( i < us.size() - 1 ) {
-                const Parser::Action& next = us.get_action( i + 1 );
-                if ( typeid( next ) == typeid( Parser::Resize ) ) {
+                const Network::UserEvent& next_event = us.get_event( i + 1 );
+                if ( next_event.type == Network::ResizeType ) {
                   continue;
                 }
               }
               /* tell child process of resize */
-              const Parser::Resize& res = static_cast<const Parser::Resize&>( action );
+              const Parser::Resize& res = event.resize;
               struct winsize window_size;
               if ( ioctl( host_fd, TIOCGWINSZ, &window_size ) < 0 ) {
                 perror( "ioctl TIOCGWINSZ" );

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -32,6 +32,8 @@
 
 #include "src/include/config.h"
 
+#include <cctype>
+#include <cstdint>
 #include <cerrno>
 #include <clocale>
 #include <csignal>
@@ -262,6 +264,9 @@ void STMClient::main_init( void )
   Terminal::Complete local_terminal( window_size.ws_col, window_size.ws_row );
   network = NetworkPointer( new NetworkType( blank, local_terminal, key.c_str(), ip.c_str(), port.c_str() ) );
 
+  uint32_t capabilities = mouse_enabled ? Network::MOSH_CAP_MOUSE : 0;
+  network->set_capabilities( capabilities );
+
   network->set_send_delay( 1 ); /* minimal delay on outgoing keystrokes */
 
   /* tell server the size of the terminal */
@@ -307,6 +312,97 @@ void STMClient::process_network_input( void )
     network->get_latest_remote_state().state.get_echo_ack() );
 }
 
+bool STMClient::remote_mouse_supported( void ) const
+{
+  return mouse_enabled && network && network->supports_capability( Network::MOSH_CAP_MOUSE );
+}
+
+void STMClient::send_mouse_event( const Network::MouseEvent& event )
+{
+  if ( !network || network->shutdown_in_progress() ) {
+    return;
+  }
+
+  network->get_current_state().push_back( event );
+}
+
+STMClient::MouseParseResult STMClient::parse_mouse_sequence( const std::string& buffer,
+                                                             size_t start,
+                                                             size_t& consumed,
+                                                             Network::MouseEvent& event ) const
+{
+  consumed = 0;
+
+  if ( start >= buffer.size() ) {
+    return MouseParseResult::NotMouse;
+  }
+
+  if ( buffer[start] != '\x1b' ) {
+    return MouseParseResult::NotMouse;
+  }
+
+  if ( buffer.size() - start < 3 ) {
+    return MouseParseResult::NeedMore;
+  }
+
+  if ( buffer[start + 1] != '[' || buffer[start + 2] != '<' ) {
+    return MouseParseResult::NotMouse;
+  }
+
+  size_t pos = start + 3;
+  std::string fields[3];
+  int field = 0;
+
+  while ( pos < buffer.size() ) {
+    unsigned char c = buffer[pos];
+    if ( std::isdigit( c ) ) {
+      fields[field].push_back( static_cast<char>( c ) );
+    } else if ( c == ';' ) {
+      field++;
+      if ( field >= 3 ) {
+        return MouseParseResult::NotMouse;
+      }
+    } else if ( ( c == 'M' ) || ( c == 'm' ) ) {
+      if ( field != 2 ) {
+        return MouseParseResult::NotMouse;
+      }
+
+      if ( fields[0].empty() || fields[1].empty() || fields[2].empty() ) {
+        return MouseParseResult::NotMouse;
+      }
+
+      uint32_t cb = static_cast<uint32_t>( std::strtoul( fields[0].c_str(), nullptr, 10 ) );
+      uint32_t x = static_cast<uint32_t>( std::strtoul( fields[1].c_str(), nullptr, 10 ) );
+      uint32_t y = static_cast<uint32_t>( std::strtoul( fields[2].c_str(), nullptr, 10 ) );
+
+      event = Network::MouseEvent( Network::MouseEvent::CLICK,
+                                   x,
+                                   y,
+                                   c == 'm',
+                                   cb & 0x3,
+                                   cb );
+
+      if ( cb & 0x40 ) {
+        event.type = ( cb & 0x1 ) ? Network::MouseEvent::SCROLL_DOWN : Network::MouseEvent::SCROLL_UP;
+        event.release = false;
+      } else if ( cb & 0x20 ) {
+        event.type = Network::MouseEvent::MOVE;
+      } else {
+        event.type = Network::MouseEvent::CLICK;
+      }
+
+      consumed = pos - start + 1;
+      return MouseParseResult::Parsed;
+    } else {
+      return MouseParseResult::NotMouse;
+    }
+
+    pos++;
+  }
+
+  return MouseParseResult::NeedMore;
+}
+
 bool STMClient::process_user_input( int fd )
 {
   const int buf_size = 16384;
@@ -334,8 +430,29 @@ bool STMClient::process_user_input( int fd )
     overlays.get_prediction_engine().reset();
   }
 
-  for ( int i = 0; i < bytes_read; i++ ) {
-    char the_byte = buf[i];
+  const bool supports_mouse = remote_mouse_supported();
+
+  std::string input_stream = mouse_sequence_buffer;
+  input_stream.append( buf, bytes_read );
+  mouse_sequence_buffer.clear();
+
+  size_t idx = 0;
+  while ( idx < input_stream.size() ) {
+    if ( supports_mouse ) {
+      Network::MouseEvent mouse_event;
+      size_t consumed = 0;
+      MouseParseResult result = parse_mouse_sequence( input_stream, idx, consumed, mouse_event );
+      if ( result == MouseParseResult::Parsed ) {
+        send_mouse_event( mouse_event );
+        idx += consumed;
+        continue;
+      } else if ( result == MouseParseResult::NeedMore ) {
+        mouse_sequence_buffer = input_stream.substr( idx );
+        break;
+      }
+    }
+
+    char the_byte = input_stream[idx++];
 
     if ( !paste ) {
       overlays.get_prediction_engine().new_user_byte( the_byte, local_framebuffer );

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -72,6 +72,8 @@ private:
   bool repaint_requested, lf_entered, quit_sequence_started;
   bool clean_shutdown;
   unsigned int verbose;
+  bool mouse_enabled;
+  std::string mouse_sequence_buffer;
 
   void main_init( void );
   void process_network_input( void );
@@ -88,19 +90,34 @@ private:
 
   void resume( void ); /* restore state after SIGCONT */
 
+  enum class MouseParseResult
+  {
+    NotMouse,
+    NeedMore,
+    Parsed
+  };
+
+  MouseParseResult parse_mouse_sequence( const std::string& buffer,
+                                         size_t start,
+                                         size_t& consumed,
+                                         Network::MouseEvent& event ) const;
+  void send_mouse_event( const Network::MouseEvent& event );
+  bool remote_mouse_supported( void ) const;
+
 public:
   STMClient( const char* s_ip,
              const char* s_port,
              const char* s_key,
              const char* predict_mode,
              unsigned int s_verbose,
-             const char* predict_overwrite )
+             const char* predict_overwrite,
+             bool enable_mouse )
     : ip( s_ip ? s_ip : "" ), port( s_port ? s_port : "" ), key( s_key ? s_key : "" ), escape_key( 0x1E ),
       escape_pass_key( '^' ), escape_pass_key2( '^' ), escape_requires_lf( false ), escape_key_help( L"?" ),
       saved_termios(), raw_termios(), window_size(), local_framebuffer( 1, 1 ), new_state( 1, 1 ), overlays(),
       network(), display( true ) /* use TERM environment var to initialize display */, connecting_notification(),
       repaint_requested( false ), lf_entered( false ), quit_sequence_started( false ), clean_shutdown( false ),
-      verbose( s_verbose )
+      verbose( s_verbose ), mouse_enabled( enable_mouse ), mouse_sequence_buffer()
   {
     if ( predict_mode ) {
       if ( !strcmp( predict_mode, "always" ) ) {

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -51,6 +51,7 @@ using namespace Crypto;
 
 namespace Network {
 static const unsigned int MOSH_PROTOCOL_VERSION = 2; /* bumped for echo-ack */
+static const uint32_t MOSH_CAP_MOUSE = 1U << 0;
 
 uint64_t timestamp( void );
 uint16_t timestamp16( void );

--- a/src/network/networktransport-impl.h
+++ b/src/network/networktransport-impl.h
@@ -46,7 +46,8 @@ Transport<MyState, RemoteState>::Transport( MyState& initial_state,
                                             const char* desired_port )
   : connection( desired_ip, desired_port ), sender( &connection, initial_state ),
     received_states( 1, TimestampedState<RemoteState>( timestamp(), 0, initial_remote ) ),
-    receiver_quench_timer( 0 ), last_receiver_state( initial_remote ), fragments(), verbose( 0 )
+    receiver_quench_timer( 0 ), last_receiver_state( initial_remote ), fragments(), verbose( 0 ),
+    local_capabilities( 0 ), remote_capabilities( 0 )
 {
   /* server */
 }
@@ -59,7 +60,8 @@ Transport<MyState, RemoteState>::Transport( MyState& initial_state,
                                             const char* port )
   : connection( key_str, ip, port ), sender( &connection, initial_state ),
     received_states( 1, TimestampedState<RemoteState>( timestamp(), 0, initial_remote ) ),
-    receiver_quench_timer( 0 ), last_receiver_state( initial_remote ), fragments(), verbose( 0 )
+    receiver_quench_timer( 0 ), last_receiver_state( initial_remote ), fragments(), verbose( 0 ),
+    local_capabilities( 0 ), remote_capabilities( 0 )
 {
   /* client */
 }
@@ -75,6 +77,10 @@ void Transport<MyState, RemoteState>::recv( void )
 
     if ( inst.protocol_version() != MOSH_PROTOCOL_VERSION ) {
       throw NetworkException( "mosh protocol version mismatch", 0 );
+    }
+
+    if ( inst.has_capabilities() ) {
+      remote_capabilities = inst.capabilities();
     }
 
     sender.process_acknowledgment_through( inst.ack_num() );

--- a/src/network/networktransport.h
+++ b/src/network/networktransport.h
@@ -34,6 +34,7 @@
 #define NETWORK_TRANSPORT_HPP
 
 #include <csignal>
+#include <cstdint>
 #include <ctime>
 #include <list>
 #include <string>
@@ -63,6 +64,8 @@ private:
   RemoteState last_receiver_state; /* the state we were in when user last queried state */
   FragmentAssembly fragments;
   unsigned int verbose;
+  uint32_t local_capabilities;
+  uint32_t remote_capabilities;
 
 public:
   Transport( MyState& initial_state,
@@ -117,6 +120,15 @@ public:
   }
 
   void set_send_delay( int new_delay ) { sender.set_send_delay( new_delay ); }
+
+  void set_capabilities( uint32_t caps )
+  {
+    local_capabilities = caps;
+    sender.set_capabilities( caps );
+  }
+
+  uint32_t get_remote_capabilities( void ) const { return remote_capabilities; }
+  bool supports_capability( uint32_t cap ) const { return ( remote_capabilities & cap ) == cap; }
 
   uint64_t get_sent_state_acked_timestamp( void ) const { return sender.get_sent_state_acked_timestamp(); }
   uint64_t get_sent_state_acked( void ) const { return sender.get_sent_state_acked(); }

--- a/src/network/transportsender-impl.h
+++ b/src/network/transportsender-impl.h
@@ -53,7 +53,7 @@ TransportSender<MyState>::TransportSender( Connection* s_connection, MyState& in
     assumed_receiver_state( sent_states.begin() ), fragmenter(), next_ack_time( timestamp() ),
     next_send_time( timestamp() ), verbose( 0 ), shutdown_in_progress( false ), shutdown_tries( 0 ),
     shutdown_start( -1 ), ack_num( 0 ), pending_data_ack( false ), SEND_MINDELAY( 8 ), last_heard( 0 ), prng(),
-    mindelay_clock( -1 )
+    mindelay_clock( -1 ), capabilities( 0 )
 {}
 
 /* Try to send roughly two frames per RTT, bounded by limits on frame rate */
@@ -313,6 +313,11 @@ void TransportSender<MyState>::send_in_fragments( const std::string& diff, uint6
   inst.set_ack_num( ack_num );
   inst.set_throwaway_num( sent_states.front().num );
   inst.set_diff( diff );
+  if ( capabilities ) {
+    inst.set_capabilities( capabilities );
+  } else {
+    inst.clear_capabilities();
+  }
   inst.set_chaff( make_chaff() );
 
   if ( new_num == uint64_t( -1 ) ) {

--- a/src/network/transportsender.h
+++ b/src/network/transportsender.h
@@ -33,6 +33,7 @@
 #ifndef TRANSPORT_SENDER_HPP
 #define TRANSPORT_SENDER_HPP
 
+#include <cstdint>
 #include <list>
 #include <string>
 
@@ -107,6 +108,8 @@ private:
 
   uint64_t mindelay_clock; /* time of first pending change to current state */
 
+  uint32_t capabilities;
+
 public:
   /* constructor */
   TransportSender( Connection* s_connection, MyState& initial_state );
@@ -163,6 +166,9 @@ public:
   bool shutdown_ack_timed_out( void ) const;
 
   void set_send_delay( int new_delay ) { SEND_MINDELAY = new_delay; }
+
+  void set_capabilities( uint32_t caps ) { capabilities = caps; }
+  uint32_t get_capabilities( void ) const { return capabilities; }
 
   unsigned int send_interval( void ) const;
 

--- a/src/protobufs/transportinstruction.proto
+++ b/src/protobufs/transportinstruction.proto
@@ -15,4 +15,9 @@ message Instruction {
   optional bytes diff = 6;
 
   optional bytes chaff = 7;
+
+  // Bitmask describing the capabilities supported by the sender. Introduced
+  // for negotiating optional features such as mouse forwarding while
+  // remaining backward compatible with older peers.
+  optional uint32 capabilities = 8;
 }

--- a/src/protobufs/userinput.proto
+++ b/src/protobufs/userinput.proto
@@ -21,7 +21,24 @@ message ResizeMessage {
   optional int32 height = 6;
 }
 
+message MouseEvent {
+  enum Type {
+    MOVE = 0;
+    CLICK = 1;
+    SCROLL_UP = 2;
+    SCROLL_DOWN = 3;
+  }
+
+  optional Type type = 1;
+  optional uint32 x = 2;
+  optional uint32 y = 3;
+  optional bool release = 4;
+  optional uint32 button = 5;
+  optional uint32 encoded = 6;
+}
+
 extend Instruction {
   optional Keystroke keystroke = 2;
   optional ResizeMessage resize = 3;
+  optional MouseEvent mouse = 4;
 }

--- a/src/statesync/user.cc
+++ b/src/statesync/user.cc
@@ -89,6 +89,18 @@ std::string UserStream::diff_from( const UserStream& existing ) const
         new_inst->MutableExtension( resize )->set_width( my_it->resize.width );
         new_inst->MutableExtension( resize )->set_height( my_it->resize.height );
       } break;
+      case MouseType: {
+        Instruction* new_inst = output.add_instruction();
+        ClientBuffers::MouseEvent* mouse_inst = new_inst->MutableExtension( mouse );
+        mouse_inst->set_type( static_cast<ClientBuffers::MouseEvent_Type>( my_it->mouse.type ) );
+        mouse_inst->set_x( my_it->mouse.x );
+        mouse_inst->set_y( my_it->mouse.y );
+        mouse_inst->set_release( my_it->mouse.release );
+        mouse_inst->set_button( my_it->mouse.button );
+        if ( my_it->mouse.encoded ) {
+          mouse_inst->set_encoded( my_it->mouse.encoded );
+        }
+      } break;
       default:
         assert( !"unexpected event type" );
         break;
@@ -114,6 +126,15 @@ void UserStream::apply_string( const std::string& diff )
     } else if ( input.instruction( i ).HasExtension( resize ) ) {
       actions.push_back( UserEvent( Resize( input.instruction( i ).GetExtension( resize ).width(),
                                             input.instruction( i ).GetExtension( resize ).height() ) ) );
+    } else if ( input.instruction( i ).HasExtension( mouse ) ) {
+      const ClientBuffers::MouseEvent& mouse_inst = input.instruction( i ).GetExtension( mouse );
+      MouseEvent::Type type = static_cast<MouseEvent::Type>( mouse_inst.type() );
+      uint32_t x = mouse_inst.has_x() ? mouse_inst.x() : 0;
+      uint32_t y = mouse_inst.has_y() ? mouse_inst.y() : 0;
+      bool release = mouse_inst.has_release() ? mouse_inst.release() : false;
+      uint32_t button = mouse_inst.has_button() ? mouse_inst.button() : 0;
+      uint32_t encoded = mouse_inst.has_encoded() ? mouse_inst.encoded() : 0;
+      actions.push_back( UserEvent( MouseEvent( type, x, y, release, button, encoded ) ) );
     }
   }
 }
@@ -125,6 +146,10 @@ const Parser::Action& UserStream::get_action( unsigned int i ) const
       return actions[i].userbyte;
     case ResizeType:
       return actions[i].resize;
+    case MouseType: {
+      static const Parser::Ignore ignore;
+      return ignore;
+    }
     default:
       assert( !"unexpected action type" );
       static const Parser::Ignore nothing = Parser::Ignore();

--- a/src/statesync/user.h
+++ b/src/statesync/user.h
@@ -34,6 +34,7 @@
 #define USER_HPP
 
 #include <cassert>
+#include <cstdint>
 #include <deque>
 #include <list>
 #include <string>
@@ -44,7 +45,41 @@ namespace Network {
 enum UserEventType
 {
   UserByteType = 0,
-  ResizeType = 1
+  ResizeType = 1,
+  MouseType = 2
+};
+
+struct MouseEvent
+{
+  enum Type
+  {
+    MOVE = 0,
+    CLICK = 1,
+    SCROLL_UP = 2,
+    SCROLL_DOWN = 3
+  };
+
+  Type type;
+  uint32_t x;
+  uint32_t y;
+  bool release;
+  uint32_t button;
+  uint32_t encoded;
+
+  MouseEvent( Type s_type = MOVE,
+              uint32_t s_x = 0,
+              uint32_t s_y = 0,
+              bool s_release = false,
+              uint32_t s_button = 0,
+              uint32_t s_encoded = 0 )
+    : type( s_type ), x( s_x ), y( s_y ), release( s_release ), button( s_button ), encoded( s_encoded )
+  {}
+
+  bool operator==( const MouseEvent& other ) const
+  {
+    return ( type == other.type ) && ( x == other.x ) && ( y == other.y ) && ( release == other.release )
+           && ( button == other.button ) && ( encoded == other.encoded );
+  }
 };
 
 class UserEvent
@@ -53,10 +88,13 @@ public:
   UserEventType type;
   Parser::UserByte userbyte;
   Parser::Resize resize;
+  MouseEvent mouse;
 
-  UserEvent( const Parser::UserByte& s_userbyte ) : type( UserByteType ), userbyte( s_userbyte ), resize( -1, -1 )
+  UserEvent( const Parser::UserByte& s_userbyte )
+    : type( UserByteType ), userbyte( s_userbyte ), resize( -1, -1 ), mouse()
   {}
-  UserEvent( const Parser::Resize& s_resize ) : type( ResizeType ), userbyte( 0 ), resize( s_resize ) {}
+  UserEvent( const Parser::Resize& s_resize ) : type( ResizeType ), userbyte( 0 ), resize( s_resize ), mouse() {}
+  UserEvent( const MouseEvent& s_mouse ) : type( MouseType ), userbyte( 0 ), resize( -1, -1 ), mouse( s_mouse ) {}
 
 private:
   UserEvent();
@@ -64,7 +102,7 @@ private:
 public:
   bool operator==( const UserEvent& x ) const
   {
-    return ( type == x.type ) && ( userbyte == x.userbyte ) && ( resize == x.resize );
+    return ( type == x.type ) && ( userbyte == x.userbyte ) && ( resize == x.resize ) && ( mouse == x.mouse );
   }
 };
 
@@ -78,10 +116,12 @@ public:
 
   void push_back( const Parser::UserByte& s_userbyte ) { actions.push_back( UserEvent( s_userbyte ) ); }
   void push_back( const Parser::Resize& s_resize ) { actions.push_back( UserEvent( s_resize ) ); }
+  void push_back( const MouseEvent& s_mouse ) { actions.push_back( UserEvent( s_mouse ) ); }
 
   bool empty( void ) const { return actions.empty(); }
   size_t size( void ) const { return actions.size(); }
   const Parser::Action& get_action( unsigned int i ) const;
+  const UserEvent& get_event( unsigned int i ) const { return actions[i]; }
 
   /* interface for Network::Transport */
   void subtract( const UserStream* prefix );

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -428,7 +428,7 @@ public:
       row = ds.get_cursor_row();
     row_pointer& mutable_row = rows.at( row );
     // If the row is shared, copy it.
-    if ( !mutable_row.unique() ) {
+    if ( mutable_row.use_count() != 1 ) {
       mutable_row = std::make_shared<Row>( *mutable_row );
     }
     return mutable_row.get();


### PR DESCRIPTION
## Summary
- expand the release workflow into Linux and macOS build matrices that generate tarballs plus native Debian and RPM packages
- extend `scripts/package-release.sh` to detect the target OS/architecture, emit checksums on any platform, and optionally build `.deb`/`.rpm` bundles via `fpm`
- document the new artifacts, installation flows, and ship a Homebrew formula so users can tap and install the fork directly

## Testing
- PACKAGE_FORMATS=deb,rpm scripts/package-release.sh

------
https://chatgpt.com/codex/tasks/task_e_68e5c7d1be2c83279a92b73031636d98